### PR TITLE
EAP 7.1 EJB client with unsecured programmatic authentication context

### DIFF
--- a/ejbclient/eap7.1-authentication-context-unsecured/README
+++ b/ejbclient/eap7.1-authentication-context-unsecured/README
@@ -1,0 +1,4 @@
+- unzip EAP distro
+- build server side, deploy
+- run client side using mvn exec:exec
+

--- a/ejbclient/eap7.1-authentication-context-unsecured/client/pom.xml
+++ b/ejbclient/eap7.1-authentication-context-unsecured/client/pom.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+
+    <groupId>client</groupId>
+    <artifactId>client</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <properties>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency> <!-- this is ejb client from EAP 7.1.0.DR19 - TODO: update after GA -->
+                <groupId>org.jboss.eap</groupId>
+                <artifactId>wildfly-ejb-client-bom</artifactId>
+                <version>7.1.0.Beta1-redhat-4</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+
+        <!-- ejb client using the EAP product BOM -->
+        <dependency>
+            <groupId>org.jboss</groupId>
+            <artifactId>jboss-ejb-client</artifactId>
+            <scope>compile</scope>
+        </dependency>
+
+        <!-- logging -->
+        <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+            <version>1.2.12</version>
+            <scope>compile</scope>
+        </dependency>
+
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>1.2.1</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <executable>java</executable>
+                    <workingDirectory>${project.build.directory}/exec-working-directory</workingDirectory>
+                    <classpathScope>runtime</classpathScope>
+                    <arguments>
+                        <argument>-classpath</argument>
+                        <classpath/>
+                        <!-- uncomment for debugging the client -->
+                        <!--<argument>-agentlib:jdwp=transport=dt_socket,address=8787,server=y,suspend=y</argument>-->
+                        <argument>client.Client</argument>
+                        <!-- the main class -->
+                    </arguments>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+
+    </build>
+
+
+    <repositories>
+        <repository>
+            <id>jboss-public-repository-group</id>
+            <name>JBoss Public Maven Repository Group</name>
+            <url>https://repository.jboss.org/nexus/content/groups/public-jboss/</url>
+            <layout>default</layout>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>never</updatePolicy>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+                <updatePolicy>never</updatePolicy>
+            </snapshots>
+        </repository>
+        <repository>
+            <id>mead</id>
+            <name>MEAD EAP7.1 build</name>
+            <url>
+                http://download.eng.bos.redhat.com/brewroot/repos/jb-eap-7.1-rhel-7-maven-build/latest/maven
+            </url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+
+    </repositories>
+
+</project>

--- a/ejbclient/eap7.1-authentication-context-unsecured/client/src/main/java/client/Client.java
+++ b/ejbclient/eap7.1-authentication-context-unsecured/client/src/main/java/client/Client.java
@@ -1,0 +1,43 @@
+package client;
+
+import java.security.PrivilegedActionException;
+import java.util.Properties;
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+
+import org.wildfly.naming.client.WildFlyInitialContextFactory;
+import org.wildfly.security.auth.client.AuthenticationConfiguration;
+import org.wildfly.security.auth.client.AuthenticationContext;
+import org.wildfly.security.auth.client.MatchRule;
+
+import ejb.HelloBeanRemote;
+
+/**
+ * @author jmartisk
+ */
+public class Client {
+
+    public static void main(String[] args) throws NamingException, PrivilegedActionException {
+        AuthenticationConfiguration common = AuthenticationConfiguration.empty()
+                .useProtocol("remote+http")
+                .useHost("127.0.0.1")
+                .usePort(8080);
+        final AuthenticationContext authCtx = AuthenticationContext.empty().with(MatchRule.ALL, common);
+
+        AuthenticationContext.getContextManager().setThreadDefault(authCtx);
+
+        InitialContext ctx = new InitialContext(getCtxProperties());
+        String lookupName = "ejb:/server/HelloBean!ejb.HelloBeanRemote";
+        HelloBeanRemote bean = (HelloBeanRemote)ctx.lookup(lookupName);
+        System.out.println(bean.hello());
+        ctx.close();
+    }
+
+    public static Properties getCtxProperties() {
+        Properties props = new Properties();
+        props.put(Context.INITIAL_CONTEXT_FACTORY, WildFlyInitialContextFactory.class.getName());
+        return props;
+    }
+
+}

--- a/ejbclient/eap7.1-authentication-context-unsecured/client/src/main/java/ejb/HelloBeanRemote.java
+++ b/ejbclient/eap7.1-authentication-context-unsecured/client/src/main/java/ejb/HelloBeanRemote.java
@@ -1,0 +1,11 @@
+package ejb;
+
+/**
+ * @author jmartisk
+ */
+public interface HelloBeanRemote {
+
+    public String hello();
+
+}
+

--- a/ejbclient/eap7.1-authentication-context-unsecured/client/src/main/resources/jboss-ejb-client.properties
+++ b/ejbclient/eap7.1-authentication-context-unsecured/client/src/main/resources/jboss-ejb-client.properties
@@ -1,0 +1,6 @@
+remote.connections=default
+
+remote.connection.default.host=127.0.0.1
+remote.connection.default.port=8080
+
+

--- a/ejbclient/eap7.1-authentication-context-unsecured/client/src/main/resources/log4j.properties
+++ b/ejbclient/eap7.1-authentication-context-unsecured/client/src/main/resources/log4j.properties
@@ -1,0 +1,6 @@
+log4j.rootLogger=ALL, stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Threshold=INFO
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{HH:mm:ss,SSS} %-5p [%C:%L] %m%n

--- a/ejbclient/eap7.1-authentication-context-unsecured/server/pom.xml
+++ b/ejbclient/eap7.1-authentication-context-unsecured/server/pom.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+
+    <groupId>server</groupId>
+    <artifactId>server</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <properties>
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.6</maven.compiler.source>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>javax</groupId>
+            <artifactId>javaee-api</artifactId>
+            <version>6.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.ejb3</groupId>
+            <artifactId>jboss-ejb3-ext-api</artifactId>
+            <version>1.1.1</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>server</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.jboss.as.plugins</groupId>
+                <artifactId>jboss-as-maven-plugin</artifactId>
+                <version>7.3.Final</version>
+            </plugin>
+        </plugins>
+    </build>
+
+    <repositories>
+        <repository>
+            <id>jboss-public-repository-group</id>
+            <name>JBoss Public Maven Repository Group</name>
+            <url>https://repository.jboss.org/nexus/content/groups/public-jboss/</url>
+            <layout>default</layout>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>never</updatePolicy>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+                <updatePolicy>never</updatePolicy>
+            </snapshots>
+        </repository>
+    </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>jboss-public-repository-group</id>
+            <name>JBoss Public Maven Repository Group</name>
+            <url>https://repository.jboss.org/nexus/content/groups/public-jboss/</url>
+            <layout>default</layout>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>never</updatePolicy>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+                <updatePolicy>never</updatePolicy>
+            </snapshots>
+        </pluginRepository>
+    </pluginRepositories>
+
+</project>

--- a/ejbclient/eap7.1-authentication-context-unsecured/server/src/main/java/ejb/HelloBean.java
+++ b/ejbclient/eap7.1-authentication-context-unsecured/server/src/main/java/ejb/HelloBean.java
@@ -1,0 +1,25 @@
+package ejb;
+
+import javax.annotation.Resource;
+import javax.annotation.security.RolesAllowed;
+import javax.ejb.SessionContext;
+import javax.ejb.Stateless;
+
+import org.jboss.ejb3.annotation.SecurityDomain;
+
+@Stateless
+public class HelloBean implements HelloBeanRemote {
+
+    @Resource
+    SessionContext ctx;
+
+    public HelloBean() {
+    }
+
+    @Override
+    public String hello() {
+        System.out.println("method hello() invoked");
+        return "ok";
+    }
+
+}

--- a/ejbclient/eap7.1-authentication-context-unsecured/server/src/main/java/ejb/HelloBeanRemote.java
+++ b/ejbclient/eap7.1-authentication-context-unsecured/server/src/main/java/ejb/HelloBeanRemote.java
@@ -1,0 +1,15 @@
+package ejb;
+
+import javax.ejb.Remote;
+
+/**
+ * @author jmartisk
+ */
+@Remote
+public interface HelloBeanRemote {
+
+    public String hello();
+
+}
+
+


### PR DESCRIPTION
* Adding an EJB client mock project configured only by unsecured programmatic authentication context (almost :))